### PR TITLE
Improving experience when user pastes an image.

### DIFF
--- a/client/views/messages/image_message.js
+++ b/client/views/messages/image_message.js
@@ -1,0 +1,28 @@
+Template.imageMessage.events({
+    "error .image-message-image": function (event, template) {
+
+        var timesRetried = 0;
+        var currentSource = event.currentTarget.src;
+        var lastPoundIndex = currentSource.lastIndexOf("#");
+
+        if(lastPoundIndex > 0) {
+            var countString = currentSource.substr(lastPoundIndex + 1);
+            var count = parseInt(countString);
+
+            if(!isNaN(count)) {
+                timesRetried = count;
+            }
+        }
+
+        if(timesRetried < 20) {
+            timesRetried++;
+            Meteor.setTimeout(function() {
+                // We store the number of retries in the # after the url
+                // This tricks the browser into reloading the image, but without changing the image received
+                // It also gives us a handy way to track the number of attempts, so we don't retry forever
+                event.currentTarget.src = template.data + "#" + timesRetried;
+            }, 500);
+        }
+
+    }
+});

--- a/client/views/messages/new_message.js
+++ b/client/views/messages/new_message.js
@@ -128,7 +128,7 @@ Template.newMessage.events({
         Session.set('unreadMessages', 0);
     },
     'paste': function(e) {
-        var items = (event.clipboardData || event.originalEvent.clipboardData).items;
+        var items = (e.clipboardData || e.originalEvent.clipboardData).items;
         var blob;
 
         var blobItem = _(items).find(function(item){return item.type.indexOf("image")===0});

--- a/client/views/messages/paste_image_modal.js
+++ b/client/views/messages/paste_image_modal.js
@@ -27,21 +27,14 @@ Template.pasteImageModal.events({
         file.name("nullchat.png");
 
         Images.insert(file, function(err, fileObj) {
-            // Super ugly hack. This callback files when the image has been inserted.
-            // However, it appears the image is not always available quite yet on AWS.
-            // This causes the error image to be shown, and the only way to get the full image is to refresh the page
-            // Pause a couple seconds to allow AWS to make the image link available.
-            // Not sure what the correct solution is here. The code is already in the only callback we have available.
-            Meteor.setTimeout(function() {
-                var fileKey = "https://s3-us-west-2.amazonaws.com/nullchat/" + fileObj.collectionName + '/' + fileObj._id + '-' + fileObj.name();
-                var messageStub = {
-                    message: fileKey,
-                    roomId: Session.get('currentRoom')
-                };
+            var fileKey = "https://s3-us-west-2.amazonaws.com/nullchat/" + fileObj.collectionName + '/' + fileObj._id + '-' + fileObj.name();
+            var messageStub = {
+                message: fileKey,
+                roomId: Session.get('currentRoom')
+            };
 
-                Meteor.call('message', messageStub);
-                scrollChatToBottom(); //TODO: This looks like an ugly hack
-            }, 2000);
+            Meteor.call('message', messageStub);
+            scrollChatToBottom(); //TODO: This looks like an ugly hack
         });
         AntiModals.dismissOverlay(e.target, null, null);
     },


### PR DESCRIPTION
Currently there's a 2 second delay to allow the image to propogate. However this isn't sufficient in all cases, resulting in broken images in chat.

Now the image_message listens for the error event. It will then attempt to reload the image 500 ms later. It reloads the image by changing the url in a non-destructive way; this fools the browser into reloading the image, even though the image referenced hasn't changed.

It also stores the number of attempts in the url, so it knows how many times it has tried. It will stop trying after 20 attempts (~10 sec).
